### PR TITLE
Mob의 currentHP 초기화 버그 수정

### DIFF
--- a/Source/Dungeon_Armory/Private/Characters/Core/Component/CharacterStatComponent.cpp
+++ b/Source/Dungeon_Armory/Private/Characters/Core/Component/CharacterStatComponent.cpp
@@ -17,8 +17,6 @@ UCharacterStatComponent::UCharacterStatComponent()
 	{
 		OwnerCharacter = Mob;
 	}
-
-	CurrentHealth = MaxHealth;
 }
 
 // Called when the game starts
@@ -26,14 +24,15 @@ void UCharacterStatComponent::BeginPlay()
 {
 	Super::BeginPlay();
 
+
 	auto World = GetWorld();
 	if (World)
 	{
 		Stamina.Initialize(World);
 	}
 
-
 	SetSpeed(BaseSpeed);
+	CurrentHealth = MaxHealth;
 	
 }
 void UCharacterStatComponent::ApplySpeedModifier(float SpeedMultiplier, float Duration)


### PR DESCRIPTION
생성자에서 BeginPlay()로 이동하여 값 수정 불가한 현상 해결